### PR TITLE
Panels wrap now, instead of just floating off the right side of the screen into infinity.

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -37,6 +37,7 @@ select   {
   border: 1px solid sienna;
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
   margin: 10px;
   padding: 10px;
 }


### PR DESCRIPTION
Most noticeable with Apprentices, but affects every `.container` element. At the moment, pretty much everything is wrapped in a `.container` element, so this also solves the problem when we have a large number of resources, items, industries, etc.

This way, we can arbitrarily change the size of the container, and the panels will still display intelligently. Flexbox ♥️.

To test:

* Check out master
* Spawn about a billion apprentices
* Lose track of them as they leave the right side of the screen

Then...

* Check out this branch
* Spawn about a billion apprentices
* Notice how they wrap, staying on the screen
* For extra fun, resize the screen. Happiness.