### PR TITLE
add dependency injection of global state

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "babel-preset-env": "^1.7.0",
     "babel-preset-stage-1": "^6.24.1",
     "css-loader": "^0.28.11",
+    "lodash": "^4.17.10",
     "node-sass": "^4.9.0",
     "react": "^16.3.2",
     "react-dom": "^16.3.2",

--- a/src/app.js
+++ b/src/app.js
@@ -2,12 +2,12 @@ import autobind from 'autobind-decorator';
 import React from 'react';
 
 import { SpinachGarden, IronMine, TinMine } from './models/industries';
-import _items from './models/items';
+import bind_items from './models/items';
 import Apprentice from './models/apprentices.js';
-import Debug from './views/debug.js';
-import { Counter, Button } from './views/lib';
 import { Spinach, Iron, Tin, Lead, Gold } from './models/resources.js';
 
+import { Counter, Button } from './views/lib';
+import Debug from './views/debug.js';
 import Alchemy from './views/alchemy';
 import Help from './views/help';
 import Industry from './views/industry';
@@ -41,7 +41,7 @@ class App extends React.Component {
       maxGold: 0,
       amAssigning: false,
     };
-    this.state.items = _items(fu, this.state);
+    this.state.items = bind_items(fu, this.state);
     this.state.resources.lead.setQuantity(10);
     this.RPOT.run();
 
@@ -100,7 +100,7 @@ class App extends React.Component {
           resources={this.state.resources}
           transmute = {this.transmute.bind(this)}
         />
-        <Shop items={this.state.items} />
+        <Shop items={Object.values(this.state.items)} />
         <Help
           apprentices={this.state.apprentices}
           onHire={this.hireApprentice}

--- a/src/app.js
+++ b/src/app.js
@@ -1,10 +1,12 @@
 import autobind from 'autobind-decorator';
 import React from 'react';
 
-import { SpinachGarden, IronMine, TinMine } from './models/industries';
+import bind_resources from './models/resources.js';
 import bind_items from './models/items';
+import bind_industries from './models/industries';
 import Apprentice from './models/apprentices.js';
 import { Spinach, Iron, Tin, Lead, Gold } from './models/resources.js';
+
 
 import { Counter, Button } from './views/lib';
 import Debug from './views/debug.js';
@@ -22,28 +24,20 @@ class App extends React.Component {
   constructor() {
     super();
     const fu = this.forceUpdate.bind(this);
-    this.RPOT = new RelentlessPassageOfTime(fu);
     this.state = {
-      resources: {
-        spinach: new Spinach(fu),
-        iron: new Iron(fu),
-        tin: new Tin(fu),
-        lead: new Lead(fu),
-        gold: new Gold(fu),
-      },
-      industries: {
-        spinachGarden: new SpinachGarden(this.RPOT, fu),
-        ironMine: new IronMine(this.RPOT, fu),
-        tinMine: new TinMine(this.RPOT, fu),
-      },
+      RPOT: new RelentlessPassageOfTime(fu),
+      resources: {},
       items: {},
+      industries: {},
       apprentices: [],
       maxGold: 0,
       amAssigning: false,
     };
     this.state.items = bind_items(fu, this.state);
-    this.state.resources.lead.setQuantity(10);
-    this.RPOT.run();
+    this.state.resources = bind_resources(fu, this.state);
+    this.state.industries = bind_industries(fu, this.state);
+    this.state.resources.lead.setQuantity(5);
+    this.state.RPOT.run();
 
     // debugging hackery
     window.globalState = this.state;
@@ -51,7 +45,7 @@ class App extends React.Component {
 
   @autobind
   hireApprentice() {
-    this.setState({apprentices: [...this.state.apprentices, new Apprentice(this.RPOT)]});
+    this.setState({apprentices: [...this.state.apprentices, new Apprentice(this.state.RPOT)]});
   }
 
   transmute(from, to) {

--- a/src/models/industries.js
+++ b/src/models/industries.js
@@ -1,75 +1,91 @@
-class Industry {
-  constructor(RPOT, forceUpdate) {
-    this.name = 'unnamed resource';
-    this.label = 'Unnamed Resource';
-    this.targetResource = 'untargeted industry';
-    this.costToBuild = 10;
-    this.maxQuantity = 0;
-    this.incrementMaxBy = 10;
-    this.quantity = 0;
-    this.lastTick = 0;
-    this.tickLength = 1000;
-    this.forceAppUpdate = forceUpdate;
-    RPOT.subscribe(this);
-  }
+export default (forceUpdate, globalState) => {
 
-  tick(now) {
-    if (now > this.lastTick + this.tickLength) {
-      this.lastTick = now;
-      if (this.quantity < this.maxQuantity) this.quantity += 1;
-      return true;
+  class Industry {
+    constructor() {
+      this.label = 'Unnamed Industry';
+      this.name = 'unnamedIndustry';
+      this.targetResource = 'untargeted industry';
+      this.costToBuild = 10;
+      this.maxQuantity = 0;
+      this.incrementMaxBy = 10;
+      this.quantity = 0;
+      this.lastTick = 0;
+      this.tickLength = 1000;
+      globalState.RPOT.subscribe(this);
     }
-    return false;
+
+    tick(now) {
+      if (now > this.lastTick + this.tickLength) {
+        this.lastTick = now;
+        if (this.quantity < this.maxQuantity) this.quantity += 1;
+        return true;
+      }
+      return false;
+    }
+
+    build(gold) {
+      this.maxQuantity += this.incrementMaxBy;
+      gold.quantity -= this.costToBuild;
+      this.increaseBuildCost();
+      forceUpdate();
+    }
+
+    collect(resource) {
+      resource.incrementBy(this.quantity);
+      this.quantity = 0;
+      forceUpdate();
+    }
+
+    canAfford(gold) {
+      return gold < this.costToBuild
+    }
+
+    increaseBuildCost() {
+      this.costToBuild = this.costToBuild ** 2;
+    }
   }
 
-  build(gold) {
-    this.maxQuantity += this.incrementMaxBy;
-    gold.quantity -= this.costToBuild;
-    this.increaseBuildCost();
-    this.forceAppUpdate();
+  class SpinachGarden extends Industry {
+    constructor() {
+      super();
+      this.name = 'spinachGarden';
+      this.label = 'Spinach Garden';
+      this.targetResource = 'spinach';
+    }
   }
 
-  collect(resource) {
-    resource.incrementBy(this.quantity);
-    this.quantity = 0;
-    this.forceAppUpdate();
+  class IronMine extends Industry {
+    constructor() {
+      super();
+      this.name = 'ironMine';
+      this.label = 'Iron Mine';
+      this.targetResource = 'iron';
+    }
   }
 
-  canAfford(gold) {
-    return gold < this.costToBuild
+  class TinMine extends Industry {
+    constructor() {
+      super();
+      this.name = 'tinMine';
+      this.label = 'Tin Mine';
+      this.targetResource = 'tin';
+    }
   }
 
-  increaseBuildCost() {
-    this.costToBuild = this.costToBuild ** 2;
+  var industries_array = [
+    new SpinachGarden(),
+    new IronMine(),
+    new TinMine(),
+  ];
+
+  var industries_object = {};
+  for (var item of industries_array) {
+    industries_object[item.name] = item;
   }
+  return industries_object;
+
+
+
+
 }
 
-class SpinachGarden extends Industry {
-  constructor(RPOT, forceAppUpdate) {
-    super(RPOT, forceAppUpdate);
-    this.name = 'spinachGarden';
-    this.label = 'Spinach Garden';
-    this.targetResource = 'spinach';
-  }
-}
-
-class IronMine extends Industry {
-  constructor(RPOT, forceAppUpdate) {
-    super(RPOT, forceAppUpdate);
-    this.name = 'ironMine';
-    this.label = 'Iron Mine';
-    this.targetResource = 'iron';
-  }
-}
-
-class TinMine extends Industry {
-  constructor(RPOT, forceAppUpdate) {
-    super(RPOT, forceAppUpdate);
-    this.name = 'tinMine';
-    this.label = 'Tin Mine';
-    this.targetResource = 'tin';
-  }
-}
-
-export { SpinachGarden, IronMine, TinMine };
-export default Industry;

--- a/src/models/items.js
+++ b/src/models/items.js
@@ -3,7 +3,7 @@ export default (forceUpdate, globalState) => {
   class Item {
     constructor(config) {
       this.label = config.label || 'Unnamed Item';
-      this.name = config.name || config.label;
+      this.name = config.name || _.camelCase(this.label);
       this.description = config.description || 'A rare glimpse behind the curtain. Probably here by accident.';
       this.unlocked = config.unlocked || false;
       this.tier = 0;
@@ -32,7 +32,7 @@ export default (forceUpdate, globalState) => {
     }
   }
 
-  return [
+  var items_array = [
     new Item({
       label: 'Lead Catalyst', 
       description: 'Reduces the amount of lead required to produce gold',
@@ -50,5 +50,11 @@ export default (forceUpdate, globalState) => {
       },
     }),
   ];
+
+  var items_object = {};
+  for (var item of items_array) {
+    items_object[item.name] = item;
+  }
+  return items_object;
 
 }

--- a/src/models/resources.js
+++ b/src/models/resources.js
@@ -1,116 +1,130 @@
-class Resource {
-  constructor(forceUpdate) {
-    this.forceAppUpdate = forceUpdate;
-    this.quantity = 0; // Current quantity
-    this.produced = 0; // Amount produced ever, i.e. ignoring spent
-    this.name = 'unnamed resource';
-    this.label = 'Unnamed Resource';
-    this.unlocked = false;
-    this.transmutationTargets = {};
-    this.findVolume = 1;
-    this.find = () => this.quantity += this.findVolume;
-  }
+export default (forceUpdate, globalState) => {
 
-  setQuantity(q) {
-    this.quantity = q;
-  }
-
-  incrementBy(q) {
-    this.quantity += q;
-    this.produced += q;
-  }
-
-  canTransmuteTo(target) {
-    if (!target) return false;
-    return this.transmutationTargets[target.name] && this.transmutationTargets[target.name] <= this.quantity;
-  }
-
-  transmute(target) {
-    if (this.canTransmuteTo(target)) {
-      this.incrementBy(-1 * this.transmutationTargets[target.name]);
-      this.forceAppUpdate();
-      return true;
+  class Resource {
+    constructor() {
+      this.quantity = 0; // Current quantity
+      this.produced = 0; // Amount produced ever, i.e. ignoring spent
+      this.name = 'unnamed resource';
+      this.label = 'Unnamed Resource';
+      this.unlocked = false;
+      this.transmutationTargets = {};
+      this.findVolume = 1;
+      this.find = () => this.quantity += this.findVolume;
     }
-    return false;
-  }
-}
 
-class Spinach extends Resource {
-  constructor(forceUpdate) {
-    super(forceUpdate)
-    this.label = 'Spinach';
-    this.name = 'spinach';
-    this.quantity = 0;
-    this.unlocked = true;
-    this.verb = 'Pluck';
-    this.transmutationTargets = {iron: 3};
-    this.find = () => {
-      this.quantity += this.findVolume;
-      this.forceAppUpdate();
-    };
-  }
-}
+    setQuantity(q) {
+      this.quantity = q;
+    }
 
-class Iron extends Resource {
-  constructor(forceUpdate) {
-    super(forceUpdate)
-    this.label = 'Iron';
-    this.name = 'iron';
-    this.quantity = 0;
-    this.unlocked = true;
-    this.verb = 'Scrounge';
-    this.transmutationTargets = {lead: 2};
-    this.find = () => {
-      this.quantity += this.findVolume;
-      this.forceAppUpdate();
-    };
-  }
-}
+    incrementBy(q) {
+      this.quantity += q;
+      this.produced += q;
+    }
 
-class Tin extends Resource {
-  constructor(forceUpdate) {
-    super(forceUpdate)
-    this.label = 'Tin';
-    this.name = 'tin';
-    this.quantity = 0;
-    this.unlocked = true;
-    this.verb = 'Scrounge';
-    this.transmutationTargets = {iron: 4, lead: 10};
-    this.find = () => {
-      this.quantity += this.findVolume;
-      this.forceAppUpdate();
-    };
-  }
-}
+    canTransmuteTo(target) {
+      if (!target) return false;
+      return this.transmutationTargets[target.name] && this.transmutationTargets[target.name] <= this.quantity;
+    }
 
-class Lead extends Resource {
-  constructor(forceUpdate) {
-    super(forceUpdate)
-    this.label = 'Lead';
-    this.name = 'lead';
-    this.quantity = 0;
-    this.unlocked = true;
-    this.verb = 'Scrounge';
-    this.transmutationTargets = {gold: 10};
-    this.find = () => {
-      this.quantity += this.findVolume;
-      this.forceAppUpdate();
-    };
+    transmute(target) {
+      if (this.canTransmuteTo(target)) {
+        this.incrementBy(-1 * this.transmutationTargets[target.name]);
+        forceUpdate();
+        return true;
+      }
+      return false;
+    }
   }
-}
 
-class Gold extends Resource {
-  constructor(forceUpdate) {
-    super(forceUpdate)
-    this.label = 'Gold';
-    this.name = 'gold';
-    this.quantity = 0;
-    this.unlocked = true;
-    this.verb = '💥';
-    this.transmutationTargets = [];
-    this.find = null;
+  class Spinach extends Resource {
+    constructor() {
+      super()
+      this.label = 'Spinach';
+      this.name = 'spinach';
+      this.quantity = 0;
+      this.unlocked = true;
+      this.verb = 'Pluck';
+      this.transmutationTargets = {iron: 3};
+      this.find = () => {
+        this.quantity += this.findVolume;
+        forceUpdate();
+      };
+    }
   }
-}
 
-export { Spinach, Iron, Tin, Lead, Gold };
-export default Resource;
+  class Iron extends Resource {
+    constructor() {
+      super()
+      this.label = 'Iron';
+      this.name = 'iron';
+      this.quantity = 0;
+      this.unlocked = true;
+      this.verb = 'Scrounge';
+      this.transmutationTargets = {lead: 2};
+      this.find = () => {
+        this.quantity += this.findVolume;
+        forceUpdate();
+      };
+    }
+  }
+
+  class Tin extends Resource {
+    constructor() {
+      super()
+      this.label = 'Tin';
+      this.name = 'tin';
+      this.quantity = 0;
+      this.unlocked = true;
+      this.verb = 'Scrounge';
+      this.transmutationTargets = {iron: 4, lead: 10};
+      this.find = () => {
+        this.quantity += this.findVolume;
+        forceUpdate();
+      };
+    }
+  }
+
+  class Lead extends Resource {
+    constructor() {
+      super()
+      this.label = 'Lead';
+      this.name = 'lead';
+      this.quantity = 0;
+      this.unlocked = true;
+      this.verb = 'Scrounge';
+      this.transmutationTargets = {gold: 10};
+      this.find = () => {
+        this.quantity += this.findVolume;
+        forceUpdate();
+      };
+    }
+  }
+
+  class Gold extends Resource {
+    constructor() {
+      super()
+      this.label = 'Gold';
+      this.name = 'gold';
+      this.quantity = 0;
+      this.unlocked = true;
+      this.verb = '💥';
+      this.transmutationTargets = [];
+      this.find = null;
+    }
+  }
+
+  var resources_array = [
+    new Spinach(),
+    new Iron(),
+    new Tin(),
+    new Lead(),
+    new Gold(),
+  ];
+
+  var resources_object = {};
+  for (var item of resources_array) {
+    resources_object[item.name] = item;
+  }
+  return resources_object;
+
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,6 +36,12 @@ const config = {
       },
     ]
   },
+  plugins: [
+    new webpack.ProvidePlugin({
+      $: 'jquery',
+      _: 'lodash',
+    })
+  ]
 };
 
 module.exports = config;


### PR DESCRIPTION
Aside from a tidying-up of Items, this affects Resources and Industries.

It is intended to make it easier to read global game-state from within individual models.  This is a precursor to moving all existing game mechanics to a WriteSelfReadOther (WSRO) strategy.

NOTE TO REVIEWERS: the changes to `models/industries.js` and `models/resources.js` are easier to understand if you turn off whitespace comparison, because my change meant a re-indent of the entire file.